### PR TITLE
feat: Add copy-to-clipboard for request/response body content (image or text)

### DIFF
--- a/axer/src/androidMain/kotlin/io/github/orioneee/internal/utils/ClipboardUtils.android.kt
+++ b/axer/src/androidMain/kotlin/io/github/orioneee/internal/utils/ClipboardUtils.android.kt
@@ -1,0 +1,23 @@
+package io.github.orioneee.internal.utils
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.core.content.FileProvider
+import io.github.orioneee.internal.koin.IsolatedContext
+import org.koin.core.component.inject
+import java.io.File
+
+actual suspend fun copyImageToClipboard(imageBytes: ByteArray) {
+    val context: Context by IsolatedContext.koin.inject()
+    val file = File(context.cacheDir, "axer_clipboard_image.png")
+    file.writeBytes(imageBytes)
+
+    val authority = "${context.packageName}.io.orioneee.axer.provider"
+    val uri = FileProvider.getUriForFile(context, authority, file)
+
+    val clip = ClipData.newUri(context.contentResolver, "Image", uri)
+    val clipboardManager =
+        context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    clipboardManager.setPrimaryClip(clip)
+}

--- a/axer/src/commonMain/kotlin/io/github/orioneee/internal/presentation/components/BodySection.kt
+++ b/axer/src/commonMain/kotlin/io/github/orioneee/internal/presentation/components/BodySection.kt
@@ -10,9 +10,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,6 +30,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.github.orioneee.axer.generated.resources.Res
+import io.github.orioneee.axer.generated.resources.share
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 internal fun BodySection(
@@ -36,6 +43,8 @@ internal fun BodySection(
     defaultExpanded: Boolean = true,
     isExpandable: Boolean = true,
     onClick: (() -> Unit)? = null,
+    onCopy: (() -> Unit)? = null,
+    copyEnabled: Boolean = false,
     colors: androidx.compose.material3.CardColors = CardDefaults.cardColors(),
 
     thickness: Dp = 8.dp,
@@ -87,12 +96,32 @@ internal fun BodySection(
                         modifier = Modifier.padding(8.dp)
                     )
                 }
-                if (isExpandable) {
-                    androidx.compose.material3.Icon(
-                        imageVector = Icons.Outlined.KeyboardArrowDown,
-                        modifier = Modifier.rotate(animatedRotation),
-                        contentDescription = null
-                    )
+                Row(
+                    verticalAlignment = Alignment.Companion.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    if (onCopy != null) {
+                        IconButton(
+                            onClick = onCopy,
+                            enabled = copyEnabled,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Outlined.ContentCopy,
+                                contentDescription = stringResource(Res.string.share),
+                                tint = if (copyEnabled)
+                                    LocalContentColor.current
+                                else
+                                    LocalContentColor.current.copy(alpha = 0.38f)
+                            )
+                        }
+                    }
+                    if (isExpandable) {
+                        androidx.compose.material3.Icon(
+                            imageVector = Icons.Outlined.KeyboardArrowDown,
+                            modifier = Modifier.rotate(animatedRotation),
+                            contentDescription = null
+                        )
+                    }
                 }
             }
 

--- a/axer/src/commonMain/kotlin/io/github/orioneee/internal/presentation/screens/requests/details/RequestDetailsScreen.kt
+++ b/axer/src/commonMain/kotlin/io/github/orioneee/internal/presentation/screens/requests/details/RequestDetailsScreen.kt
@@ -115,6 +115,7 @@ import io.github.orioneee.internal.presentation.components.ScreenLayout
 import io.github.orioneee.internal.presentation.components.buildStringSection
 import io.github.orioneee.internal.presentation.components.canSwipePage
 import io.github.orioneee.internal.utils.DataExporter
+import io.github.orioneee.internal.utils.copyImageToClipboard
 import io.github.orioneee.internal.utils.toHarFile
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
@@ -407,6 +408,8 @@ internal class RequestDetailsScreen {
         request: TransactionFull,
         viewModel: RequestDetailsViewModel
     ) {
+        val clipboardManager = LocalClipboardManager.current
+        val scope = rememberCoroutineScope()
         BoxWithConstraints {
             Column(
                 modifier = Modifier.Companion
@@ -502,6 +505,18 @@ internal class RequestDetailsScreen {
                         colors = CardDefaults.cardColors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant,
                         ),
+                        onCopy = {
+                            val body = request.requestBody ?: return@BodySection
+                            when (selected) {
+                                BodyType.JSON, BodyType.RAW_TEXT -> {
+                                    clipboardManager.setText(AnnotatedString(body.decodeToString()))
+                                }
+                                BodyType.IMAGE -> {
+                                    scope.launch { copyImageToClipboard(body) }
+                                }
+                            }
+                        },
+                        copyEnabled = selected != BodyType.IMAGE,
                     ) {
                         SelectionContainer {
                             Box(
@@ -571,6 +586,8 @@ internal class RequestDetailsScreen {
         request: TransactionFull,
         viewModel: RequestDetailsViewModel
     ) {
+        val clipboardManager = LocalClipboardManager.current
+        val scope = rememberCoroutineScope()
         BoxWithConstraints {
             Column(
                 modifier = Modifier
@@ -656,6 +673,18 @@ internal class RequestDetailsScreen {
                         colors = CardDefaults.cardColors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant,
                         ),
+                        onCopy = {
+                            val body = request.responseBody ?: return@BodySection
+                            when (selected) {
+                                BodyType.JSON, BodyType.RAW_TEXT -> {
+                                    clipboardManager.setText(AnnotatedString(body.decodeToString()))
+                                }
+                                BodyType.IMAGE -> {
+                                    scope.launch { copyImageToClipboard(body) }
+                                }
+                            }
+                        },
+                        copyEnabled = selected != BodyType.IMAGE || request.responseDefaultType == BodyType.IMAGE,
                     ) {
                         SelectionContainer {
                             Box(

--- a/axer/src/commonMain/kotlin/io/github/orioneee/internal/utils/ClipboardUtils.kt
+++ b/axer/src/commonMain/kotlin/io/github/orioneee/internal/utils/ClipboardUtils.kt
@@ -1,0 +1,3 @@
+package io.github.orioneee.internal.utils
+
+expect suspend fun copyImageToClipboard(imageBytes: ByteArray)

--- a/axer/src/iosMain/kotlin/io/github/orioneee/internal/utils/ClipboardUtils.ios.kt
+++ b/axer/src/iosMain/kotlin/io/github/orioneee/internal/utils/ClipboardUtils.ios.kt
@@ -1,0 +1,18 @@
+package io.github.orioneee.internal.utils
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.create
+import platform.UIKit.UIImage
+import platform.UIKit.UIPasteboard
+
+@OptIn(ExperimentalForeignApi::class)
+actual suspend fun copyImageToClipboard(imageBytes: ByteArray) {
+    val nsData = imageBytes.usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = imageBytes.size.toULong())
+    }
+    val image = UIImage.imageWithData(nsData) ?: return
+    UIPasteboard.generalPasteboard.image = image
+}

--- a/axer/src/jvmMain/kotlin/io/github/orioneee/internal/utils/ClipboardUtils.jvm.kt
+++ b/axer/src/jvmMain/kotlin/io/github/orioneee/internal/utils/ClipboardUtils.jvm.kt
@@ -1,0 +1,26 @@
+package io.github.orioneee.internal.utils
+
+import java.awt.Image
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
+import java.io.ByteArrayInputStream
+import javax.imageio.ImageIO
+
+actual suspend fun copyImageToClipboard(imageBytes: ByteArray) {
+    val image = ImageIO.read(ByteArrayInputStream(imageBytes)) ?: return
+    val transferable = object : Transferable {
+        override fun getTransferDataFlavors(): Array<DataFlavor> =
+            arrayOf(DataFlavor.imageFlavor)
+
+        override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+            flavor == DataFlavor.imageFlavor
+
+        override fun getTransferData(flavor: DataFlavor): Any {
+            if (flavor == DataFlavor.imageFlavor) return image
+            throw UnsupportedFlavorException(flavor)
+        }
+    }
+    Toolkit.getDefaultToolkit().systemClipboard.setContents(transferable, null)
+}


### PR DESCRIPTION
What changes were made

 - New ClipboardUtils expect/actual — Multiplatform copyImageToClipboard() function with implementations for
Android (via FileProvider + ClipboardManager), iOS (via UIPasteboard), and JVM (via AWT Toolkit).
 - BodySection component — Added onCopy callback and copyEnabled parameters, rendering a ContentCopy icon
button in the header row alongside the expand arrow.
 - RequestDetailsScreen — Wired copy logic for both request and response body sections: copies text (JSON/raw)
via ClipboardManager.setText() and images via the new copyImageToClipboard().

Why the changes were necessary

Users had no way to quickly copy request/response body content from the detail view. This is a common workflow
when debugging APIs — copying a payload to paste into another tool, a bug report, or a test. Image body support
extends this to visual content.

How to test the changes

 1. Open a captured request with a JSON/text body → tap the copy icon → paste in another app → verify content
matches.
 2. Open a request with an image body → tap the copy icon → paste in an image-capable app → verify image
matches.
 3. Verify the copy button is disabled when BodyType.IMAGE is selected on the request side (no native image in
request is expected).
 4. Verify the copy button is enabled for image responses when responseDefaultType == BodyType.IMAGE.
 5. Test on Android, iOS, and JVM/Desktop.

Breaking changes

None. The new onCopy and copyEnabled parameters on BodySection have default values (null / false), so existing
callers are unaffected.

The icon position can be moved wherever you want, but i feel that this position is OK.
--------------------------------------------------------------------------------------------------------------
 <div align="left">
<video width="100" src="https://github.com/user-attachments/assets/82f4b482-db5b-4181-a79c-d2314f2ddd9e">
</video>
</div> 


